### PR TITLE
Fix for bug in CanOpenNodeExporter_V4.Make_cname

### DIFF
--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -7,9 +7,8 @@ namespace Tests
     public class ExporterTestsV4 : CanOpenNodeExporter_V4
     {
         [Fact]
-        public void Test_cname_conversion()
+        public void Test_Make_cname_conversion()
         {
-
             if (Make_cname("axle 0 wheel right controlword") != "axle0WheelRightControlword")
                 throw (new Exception("Make_cname Conversion error"));
 
@@ -17,6 +16,18 @@ namespace Tests
                 throw (new Exception("Make_cname Conversion error"));
 
             if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("A/D unit offset value (filtered)") != "A_DUnitOffsetValueFiltered")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("80 test string") != "_80TestString")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("Eighty test string") != "eightyTestString")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("A") != "a")
                 throw (new Exception("Make_cname Conversion error"));
 
         }

--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xunit;
+using libEDSsharp;
+
+namespace Tests
+{
+    public class ExporterTestsV4 : CanOpenNodeExporter_V4
+    {
+        [Fact]
+        public void Test_cname_conversion()
+        {
+
+            if (Make_cname("axle 0 wheel right controlword") != "axle0WheelRightControlword")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("mapped object 4") != "mappedObject4")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
+                throw (new Exception("Make_cname Conversion error"));
+
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="ExporterTests.cs" />
     <Compile Include="PDOHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ExporterTestsV4.cs" />
     <Compile Include="XDDImportExportTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -664,7 +664,7 @@ OD_t *{0} = &_{0};", odname, string.Join(",\n    ", ODList)));
         /// </summary>
         /// <param name="name">string, name to convert</param>
         /// <returns>string</returns>
-        private static string Make_cname(string name)
+        protected static string Make_cname(string name)
         {
             if (name == null || name == "")
                 return "";

--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.IO;
+using System.Linq;
 
 namespace libEDSsharp
 {
@@ -669,40 +670,50 @@ OD_t *{0} = &_{0};", odname, string.Join(",\n    ", ODList)));
             if (name == null || name == "")
                 return "";
 
-            // split string to tokens, separated by non-word characters
-            string[] tokens = Regex.Split(name.Replace('-', '_'), @"[\W]+");
+            // split string to tokens, separated by non-word characters. Remove any empty strings
+            var tokens = Regex.Split(name.Replace('-', '_'), @"[\W]+").Where(s => s != String.Empty);
 
             string output = "";
             char prev = ' ';
             foreach (string tok in tokens)
             {
-                if (tok.Length == 0)
-                    continue;
-
                 char first = tok[0];
 
-                if (Char.IsDigit(first) || Char.IsDigit(prev) || (Char.IsUpper(prev) && Char.IsUpper(first)))
+                if (Char.IsUpper(prev) && Char.IsUpper(first))
                 {
-                    // add underscore, if tok starts with digit or we have two upper-case words
-                    output += "_" + tok;
+                    // add underscore, if we have two upper-case words
+                    output += "_";
                 }
-                else if (output.Length > 0)
+
+                if (tok.Length > 1 && Char.IsLetter(first))
                 {
-                    // all tokens except the first start with uppercse letter
+                    // all tokens except the first start with uppercase letter
                     output += Char.ToUpper(first) + tok.Substring(1);
-                }
-                else if (Char.IsLower(tok[1]))
-                {
-                    // first token start with lower-case letter, except whole word is uppercase
-                    output += Char.ToLower(first) + tok.Substring(1);
                 }
                 else
                 {
-                    // use token as is
+                    // use token as is and handle what the start of the output looks like outside of the loop 
                     output += tok;
                 }
 
                 prev = tok[tok.Length - 1];
+            }
+
+            if (Char.IsDigit(output[0]))
+            {
+                // output that starts with a digit needs a starting underscore 
+                output = "_" + output;
+            }
+            else if (output.Length > 1)
+            {
+                // output that doesnt start with all-cap-words should have word start with a lower case character
+                if (Char.IsLetter(output[0]) && Char.IsLower(output[1]))
+                    output = Char.ToLower(output[0]) + output.Substring(1);
+            }
+            else
+            {
+                // single character output
+                output = output.ToLower();
             }
 
             return output;


### PR DESCRIPTION
-Bug description-
EDSEditor failed on 'Export CanOpenNode..' and threw an exception. The exception was cause by referencing an array out-of-bounds. See picture for exact exception message.


-Commit Summary-
Subject: Added a test file for CanOpenNodeExporter_V4.

The method Make_cname in CanOpenNodeExporter_V4 was failing and no tests existed.
The test created was replicated from the method make_cname in CanOpenNodeExporter.
To create the test CanOpenNodeExporter_V4.Make_cname was changed from private to
protected.

Subject: Added string to test that caused an exception in Make_cname().

The string that failed when running 'Export CanOpenNode...' in the EDSEditor was
added to the test for CanOpenNodeExporter_V4.Make_cname. Other strings were also
added that tests conditions that Make_cname should handle. The exception was
caused by an array out-of-bounds error.

Subject: Fixed a bug in the CanOpenNodeExporter_V4.Make_cname.

The method would fail on a array out-of-bounds exception. This was do to and empty
string that was added to the tokens list. It was fixed by removing all empty strings
from the tokens list as was done in CanOpenNodeExporter.make_cname.

The conditions in the test for this method all failed. The method was modified
to pass the conditions in the test.

<img width="210" alt="Exception" src="https://user-images.githubusercontent.com/87715493/126685912-74761c85-2b73-4ee0-a246-9dd047114927.PNG">
