### PR TITLE
fixed mappable OD entry

### DIFF
--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -2027,7 +2027,7 @@ namespace libEDSsharp
                     }
                     if (missing)
                         mappingErrors.Add($"{PDO} 0x{indexPdo:X4},0x{subIdxPdo:X2}: missing OD entry 0x{mapIdx:X4},0x{mapSub:X2}");
-                    else if (accessPDO == AccessPDO.no || (PDO == "RPDO" && accessPDO == AccessPDO.r) || (PDO == "TPDO" && accessPDO == AccessPDO.t))
+                    else if (accessPDO == AccessPDO.no || (PDO == "RPDO" && accessPDO == AccessPDO.t) || (PDO == "TPDO" && accessPDO == AccessPDO.r))
                         mappingErrors.Add($"{PDO} 0x{indexPdo:X4},0x{subIdxPdo:X2}: not mappable OD entry 0x{mapIdx:X4},0x{mapSub:X2}");
                 }
             }


### PR DESCRIPTION
if access attribute of AccessPDO is correct, for example (PDO == "RPDO" && accessPDO == AccessPDO.r) a  "not mappable OD entry" error is thrown
