### PR TITLE
Allow instantly saving changes upon object change

### DIFF
--- a/EDSEditorGUI/DeviceODView.Designer.cs
+++ b/EDSEditorGUI/DeviceODView.Designer.cs
@@ -61,6 +61,7 @@ namespace ODEditor
             this.label23 = new System.Windows.Forms.Label();
             this.textBox_index = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.checkBox_autosave = new System.Windows.Forms.CheckBox();
             this.textBox_stringLengthMin = new System.Windows.Forms.TextBox();
             this.label22 = new System.Windows.Forms.Label();
             this.label20 = new System.Windows.Forms.Label();
@@ -464,6 +465,7 @@ namespace ODEditor
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.checkBox_autosave);
             this.groupBox1.Controls.Add(this.textBox_stringLengthMin);
             this.groupBox1.Controls.Add(this.label22);
             this.groupBox1.Controls.Add(this.label20);
@@ -495,13 +497,22 @@ namespace ODEditor
             this.groupBox1.Controls.Add(this.comboBox_accessPDO);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.groupBox1.Location = new System.Drawing.Point(0, 328);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
             this.groupBox1.Size = new System.Drawing.Size(853, 188);
             this.groupBox1.TabIndex = 33;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Object settings";
+            // 
+            // checkBox_autosave
+            // 
+            this.checkBox_autosave.Location = new System.Drawing.Point(702, 148);
+            this.checkBox_autosave.Name = "checkBox_autosave";
+            this.checkBox_autosave.Size = new System.Drawing.Size(139, 17);
+            this.checkBox_autosave.TabIndex = 35;
+            this.checkBox_autosave.Text = "Save changes on leave";
+            this.checkBox_autosave.UseVisualStyleBackColor = true;
             // 
             // textBox_stringLengthMin
             // 
@@ -1037,5 +1048,6 @@ namespace ODEditor
         private System.Windows.Forms.TextBox textBox_subIndex;
         private System.Windows.Forms.Label label23;
         private System.Windows.Forms.ToolStripMenuItem addToolStripMenuItem;
+        private System.Windows.Forms.CheckBox checkBox_autosave;
     }
 }

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -128,16 +128,35 @@ namespace ODEditor
 
         private bool Checkdirty()
         {
+            var result = false;
+
             if (button_saveChanges.BackColor == Color.Red)
             {
-                if (lastSelectedObject != null && MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNo) == DialogResult.No)
+                var answer = MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNoCancel);
+                switch (answer)
                 {
-                    return true;
+                    case DialogResult.Cancel:
+                    default:
+                        result = lastSelectedObject != null;
+                        break;
+
+                    case DialogResult.Yes:
+                        result = false;
+                        break;
+
+                    case DialogResult.No:
+                        if (lastSelectedObject != null)
+                        {
+                            ObjectSave();
+                            result = false;
+                        }
+                        break;
                 }
+
                 button_saveChanges.BackColor = default;
             }
 
-            return false;
+            return result;
         }
 
         private void ComboBoxSet(ComboBox comboBox, string item)
@@ -411,7 +430,11 @@ namespace ODEditor
 
         private void Button_saveChanges_Click(object sender, EventArgs e)
         {
+            ObjectSave();
+        }
 
+        private void ObjectSave()
+        {
             ExporterV4 = ExporterTypeV4();
             if (ExporterOld != ExporterV4)
             {

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -132,7 +132,7 @@ namespace ODEditor
 
             if (button_saveChanges.BackColor == Color.Red)
             {
-                var answer = MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNoCancel);
+                var answer = MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?\n\nYes = Lose changes\nNo = Save\nCancel = Go back and stay on the object", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNoCancel);
                 switch (answer)
                 {
                     case DialogResult.Cancel:

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -25,6 +25,7 @@ using System.Windows.Forms;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using libEDSsharp;
+
 namespace ODEditor
 {
 
@@ -132,7 +133,10 @@ namespace ODEditor
 
             if (button_saveChanges.BackColor == Color.Red)
             {
-                var answer = MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?\n\nYes = Lose changes\nNo = Save\nCancel = Go back and stay on the object", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNoCancel);
+                var answer = checkBox_autosave.Checked 
+                           ? DialogResult.No 
+                           : MessageBox.Show(String.Format("Unsaved changes on Index 0x{0:X4}/{1:X2}.\nDo you wish to switch object and loose your changes?\n\nYes = Lose changes\nNo = Save\nCancel = Go back and stay on the object", lastSelectedObject.Index, lastSelectedObject.Subindex), "Unsaved changes", MessageBoxButtons.YesNoCancel); ;
+
                 switch (answer)
                 {
                     case DialogResult.Cancel:
@@ -629,7 +633,8 @@ namespace ODEditor
                         contextMenu_subObject_removeSubItemToolStripMenuItem.Enabled = od.Subindex > 0 && od.parent != null;
                         contextMenu_subObject_removeSubItemLeaveGapToolStripMenuItem.Enabled = parent.objecttype == ObjectType.RECORD && od.Subindex > 0 && od.parent != null;
 
-                        if (listView_subObjects.FocusedItem.Bounds.Contains(e.Location) == true)
+                        
+                        if (isClickOnItem(e.Location))
                         {
                             contextMenu_subObject.Show(Cursor.Position);
                         }
@@ -638,6 +643,24 @@ namespace ODEditor
                 selectedObject = od;
                 PopulateObject();
             }
+        }
+
+        private bool isClickOnItem(Point location)
+        {
+            if (listView_subObjects.FocusedItem != null)
+            {
+                return listView_subObjects.FocusedItem.Bounds.Contains(location);
+            }
+
+            foreach (ListViewItem item in listView_subObjects.Items)
+            {
+                if (item.Bounds.Contains(location))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void ListView_subObjects_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
When editing larger profiles, annoyingly you always have to click "save" prior changing the (sub-)object. While the software detects changes and asks the user whether to lose the changes or not, it does not provide any possibility to simply say "yes, i want to keep the changes, but now let me switch the object".

This patch changes adds this missing third option to the dialog. It also adds a checkbox allowing to suppress the dialog and automatically save changes upon object change to speed up editing.

_Remark_: I have no idea, why so many lines show up changed in this merge, looking at the diffs on my cloned repository, there are only a few lines that are actually changed, even with white-space comparison.