### PR TITLE
dotnet 4.5 -> 4.8 cleanup

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2019
-#    runs-on: windows-latest # error MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found.
+    runs-on: windows-latest
 #    runs-on: ubuntu-latest # Error: setup-msbuild can only be run on Windows runners
     steps:
     - name: Checkout

--- a/EDSEditorGUI/EDSEditorGUI.csproj
+++ b/EDSEditorGUI/EDSEditorGUI.csproj
@@ -234,9 +234,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">


### PR DESCRIPTION
Looks like bootstrap still reference 4.5, and we might be able to build on windows-latest now