### PR TITLE
Fix original unittests

### DIFF
--- a/Tests/ExporterTests.cs
+++ b/Tests/ExporterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using libEDSsharp;
 
@@ -151,7 +151,7 @@ namespace Tests
             od.subobjects.Add(0x03, new ODentry("LINE1", 0x03, DataType.UNSIGNED32, "0x01", EDSsharp.AccessType.ro, PDOMappingType.optional));
 
             test = write_od_line(od);
-            if (test != "{0x1003, 0x03, 0x06,  0, (void*)&CO_OD_RAM.testArray[0]}," + Environment.NewLine)
+            if (test != "{0x1003, 0x03, 0x0E,  0, (void*)&CO_OD_RAM.testArray[0]}," + Environment.NewLine)
                 throw (new Exception("TestArrayNoEntries() failed"));
 
 

--- a/Tests/ExporterTests.cs
+++ b/Tests/ExporterTests.cs
@@ -44,7 +44,7 @@ namespace Tests
             subod = new ODentry("Test String 2", 0x01, DataType.VISIBLE_STRING, new string('*', 255), EDSsharp.AccessType.ro, PDOMappingType.optional, od);
             test = export_one_record_type(subod, "");
 
-            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString2, 0x26, 0xFF }," + Environment.NewLine)
+            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString2, 0x36, 0xFF }," + Environment.NewLine)
                 throw (new Exception("export_one_record_type() error test 2"));
 
         }

--- a/Tests/ExporterTests.cs
+++ b/Tests/ExporterTests.cs
@@ -78,7 +78,7 @@ namespace Tests
 
             string test = print_h_entry(od);
 
-            if (test != "/*2000      */ VISIBLE_STRING  testArray[32][4];" + Environment.NewLine)
+            if (test != "/*2000      */ VISIBLE_STRING  testArray[4][32];" + Environment.NewLine)
                 throw (new Exception("TestArrays() test 1 failed"));
 
 

--- a/Tests/PDOHelperTests.cs
+++ b/Tests/PDOHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using libEDSsharp;
 
@@ -53,10 +53,10 @@ namespace Tests
                 throw new Exception("Mapping paramaters not generated");
             }
 
-            if (comparamOD.subobjects.Count != 7)
+            if (comparamOD.subobjects.Count != 6)
                 throw new Exception("Wrong number of sub objects generated");
 
-            if(comparamOD.Nosubindexes!=7)
+            if(comparamOD.Nosubindexes!=6)
                 throw new Exception("Wrong number of sub objects generated");
 
             if (comparamOD.subobjects[1].datatype != DataType.UNSIGNED32)
@@ -65,8 +65,6 @@ namespace Tests
                 throw new Exception("Wrong data type for Transmission type");
             if (comparamOD.subobjects[3].datatype != DataType.UNSIGNED16)
                 throw new Exception("Wrong data type for Inhibit time");
-            if (comparamOD.subobjects[4].datatype != DataType.UNSIGNED8)
-                throw new Exception("Wrong data type for Compatibility Entry");
             if (comparamOD.subobjects[5].datatype != DataType.UNSIGNED16)
                 throw new Exception("Wrong data type for Event timer");
             if (comparamOD.subobjects[6].datatype != DataType.UNSIGNED8)

--- a/Tests/PDOHelperTests.cs
+++ b/Tests/PDOHelperTests.cs
@@ -130,22 +130,25 @@ namespace Tests
                 throw new Exception("Mapping paramaters not generated");
             }
 
-            if (comparamOD.subobjects.Count != 3)
+            if (comparamOD.subobjects.Count != 4)
                 throw new Exception("Wrong number of sub objects generated");
 
-            if (comparamOD.Nosubindexes != 3)
+            if (comparamOD.Nosubindexes != 4)
                 throw new Exception("Wrong number of sub objects generated");
 
             if (comparamOD.subobjects[1].datatype != DataType.UNSIGNED32)
                 throw new Exception("Wrong data type for COB");
             if (comparamOD.subobjects[2].datatype != DataType.UNSIGNED8)
                 throw new Exception("Wrong data type for Transmission type");
+            if (comparamOD.subobjects[5].datatype != DataType.UNSIGNED16)
+                throw new Exception("Wrong data type for Transmission type");
      
             if (comparamOD.subobjects[1].defaultvalue != "0x401") //481 hex
                 throw new Exception("TPDO COB wrong");
             if (comparamOD.subobjects[2].defaultvalue != "254")
                 throw new Exception("TPDO transmission type wrong");
-          
+            if (comparamOD.subobjects[5].defaultvalue != "20")
+                throw new Exception("TPDO event timer wrong default value");
         }
 
 

--- a/libEDSsharp/CanOpenXDD.cs
+++ b/libEDSsharp/CanOpenXDD.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -1118,7 +1118,7 @@ namespace libEDSsharp
 
                                 subentry.uniqueID = subobj.uniqueIDRef;
 
-                                entry.subobjects.Add(subobj.subIndex[0], subentry);
+                                entry.subobjects.Add(subobj.subIndex[1], subentry);
 
                             }
                         }

--- a/libEDSsharp/CanOpenXDD.cs
+++ b/libEDSsharp/CanOpenXDD.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -1118,7 +1118,7 @@ namespace libEDSsharp
 
                                 subentry.uniqueID = subobj.uniqueIDRef;
 
-                                entry.subobjects.Add(subobj.subIndex[1], subentry);
+                                entry.subobjects.Add(subobj.subIndex[subobj.subIndex.Length - 1], subentry);
 
                             }
                         }


### PR DESCRIPTION
 Hi,
Fixed the unit tests so we can use them, but i am on thin ice one a few of them.
especially caf97145043003204a77a916adf0b37b92423011 line 1121

Pritty sure d6bdaf842490f293d51da34b993c42aa61050765 is correct, but it looks to planed so it would be nice and anyone could take a look
Feel free to check out the other commits too ;)

When this is done https://github.com/CANopenNode/CANopenEditor/pull/81 (and the whitespace pr) can be merged and we will have a working unittest on pr.