### PR TITLE
add dependabot to keep github action up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This sets up dependabot to check if the actions (like actions/upload-artifact) is up to date,
if it is not it will automatically make pr. once a week.

afik there are now three actions that needs updating so it should make three pr.
![image](https://github.com/CANopenNode/CANopenEditor/assets/9848846/b545cacc-e0f4-4291-aa8e-8a8808027550)

It can also be used to keep nugets up-to-date with a little more setup