### PR TITLE
unittests: exporters of string

### DIFF
--- a/Tests/ExporterTests.cs
+++ b/Tests/ExporterTests.cs
@@ -159,6 +159,27 @@ namespace Tests
         }
 
         /// <summary>
+        /// Check the var string is exportet correctly
+        /// </summary>
+        [Theory]
+        [InlineData(1, "")]
+        [InlineData(5, "12345")]
+        void TestVarString(int expectedLength, string defaultvalue)
+        {
+            var od = new ODentry
+            {
+                objecttype = ObjectType.VAR,
+                datatype = DataType.VISIBLE_STRING,
+                parameter_name = "test string",
+                accesstype = EDSsharp.AccessType.ro,
+                Index = 0x2000
+            };
+            od.defaultvalue = defaultvalue;
+            var test = print_h_entry(od);
+            Assert.Equal(test, $"/*{od.Index:X}      */ VISIBLE_STRING testString[{expectedLength}];" + Environment.NewLine);
+        }
+
+        /// <summary>
         /// Check size of objects is correct
         /// </summary>
         [Fact]

--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Xunit;
 using libEDSsharp;
 
@@ -6,6 +8,43 @@ namespace Tests
 {
     public class ExporterTestsV4 : CanOpenNodeExporter_V4
     {
+        readonly EDSsharp _eds;
+        public ExporterTestsV4()
+        {
+            _eds = new EDSsharp();
+        }
+
+        void GetExportResult(EDSsharp eds, out IEnumerable<String> cfile, out IEnumerable<String> hfile)
+        {
+            var fullPath = Path.GetTempFileName();
+            var tempfile = Path.GetFileName(fullPath);
+            var path = Path.GetTempPath();
+
+            var cfilePath = fullPath + ".c";
+            var hfilePath = fullPath + ".h";
+            export(path, tempfile, ".", eds, "OD_Test");
+            cfile = File.ReadLines(cfilePath);
+            hfile = File.ReadLines(hfilePath);
+        }
+
+        bool FindExpectedLines(IEnumerable<String> lines, List<String> expectedLines)
+        {
+            var expectedMatchCount = expectedLines.Count;
+            var matchedCounter = 0;
+
+            foreach (var line in lines)
+            {
+                if (line == expectedLines[matchedCounter])
+                {
+                    matchedCounter++;
+
+                    if (expectedMatchCount == matchedCounter)
+                        return true;
+                }
+            }
+            return false;
+        }
+
         [Fact]
         public void Test_Make_cname_conversion()
         {
@@ -30,6 +69,215 @@ namespace Tests
             if (Make_cname("A") != "a")
                 throw (new Exception("Make_cname Conversion error"));
 
+        }
+
+        [Fact]
+        public void TestVariableStringZeroData()
+        {
+            ODentry od = new ODentry
+            {
+                objecttype = ObjectType.VAR,
+                datatype = DataType.VISIBLE_STRING,
+                parameter_name = "test string",
+                accesstype = EDSsharp.AccessType.ro,
+                Index = 0x2000
+            };
+
+            _eds.ods.Add(0x2000, od);
+
+            GetExportResult(_eds, out var cfile, out var hfile);
+            Assert.True(FindExpectedLines(hfile, new List<string> { "#define OD_Test_ENTRY_H2000 &OD_Test->list[0]" }));
+            Assert.True(FindExpectedLines(hfile, new List<string> { "#define OD_Test_ENTRY_H2000_testString &OD_Test->list[0]" }));
+
+            Assert.True(FindExpectedLines(cfile, new List<string> {
+                "static CO_PROGMEM OD_TestObjs_t OD_TestObjs = {",
+                "    .o_2000_testString = {",
+                "        .dataOrig = NULL,",
+                "        .attribute = ODA_SDO_R | ODA_STR,",
+                "        .dataLength = 0",
+                "    }",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string> {
+                "static OD_Test_ATTR_OD OD_entry_t OD_TestList[] = {",
+                "    {0x2000, 0x01, ODT_VAR, &OD_TestObjs.o_2000_testString, NULL},",
+                "    {0x0000, 0x00, 0, NULL, NULL}",
+                "};"}));
+        }
+
+        [Theory]
+        [InlineData("12345", 0, 5, "'1', '2', '3', '4', '5', 0")]
+        [InlineData("12345", 10, 10, "'1', '2', '3', '4', '5', 0, 0, 0, 0, 0, 0")]
+        public void TestVariableString(string defaultValue, uint stringLengthMin, int expectedLength, string expectedInitialValues)
+        {
+            ODentry od = new ODentry
+            {
+                objecttype = ObjectType.VAR,
+                datatype = DataType.VISIBLE_STRING,
+                parameter_name = "test string",
+                accesstype = EDSsharp.AccessType.ro,
+                Index = 0x2000,
+                defaultvalue = defaultValue
+            };
+            od.prop.CO_stringLengthMin = stringLengthMin;
+
+            _eds.ods.Add(0x2000, od);
+
+            GetExportResult(_eds, out var cfile, out var _);
+
+            Assert.True(FindExpectedLines(cfile, new List<string> {
+                "OD_Test_ATTR_RAM OD_Test_RAM_t OD_Test_RAM = {",
+               $"    .x2000_testString = {{{expectedInitialValues}}}",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string> {
+                "static CO_PROGMEM OD_TestObjs_t OD_TestObjs = {",
+                "    .o_2000_testString = {",
+                "        .dataOrig = &OD_Test_RAM.x2000_testString[0],",
+                "        .attribute = ODA_SDO_R | ODA_STR,",
+               $"        .dataLength = {expectedLength}",
+                "    }",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string> {
+                "static OD_Test_ATTR_OD OD_entry_t OD_TestList[] = {",
+                "    {0x2000, 0x01, ODT_VAR, &OD_TestObjs.o_2000_testString, NULL},",
+                "    {0x0000, 0x00, 0, NULL, NULL}",
+                "};"}));
+        }
+
+        [Theory]
+        [InlineData("", 10, 10, "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")] // only min length
+        [InlineData("12345", 10, 10, "'1', '2', '3', '4', '5', 0, 0, 0, 0, 0, 0")] // default & min length
+        [InlineData("12345", 0, 5, "'1', '2', '3', '4', '5', 0")] // default only
+        public void TestRecordWithString(string defaultValue, uint stringLengthMin, int expectedLength, string expectedInitialValues)
+        {
+            ODentry od = new ODentry
+            {
+                objecttype = ObjectType.RECORD,
+                parameter_name = "test rec",
+                accesstype = EDSsharp.AccessType.ro,
+                Index = 0x2000
+            };
+
+            od.addsubobject(0, new ODentry("numElements", 0x2000, DataType.UNSIGNED8, "0", EDSsharp.AccessType.rw, PDOMappingType.optional));
+            od.addsubobject(1, new ODentry("str", 0x2000, DataType.VISIBLE_STRING, defaultValue, EDSsharp.AccessType.rw, PDOMappingType.optional));
+            od.subobjects[1].prop.CO_stringLengthMin = stringLengthMin;
+            _eds.ods.Add(0x2000, od);
+
+            GetExportResult(_eds, out var cfile, out var hfile);
+            Assert.True(FindExpectedLines(hfile, new List<string> {
+                "typedef struct {",
+                "    struct {",
+                "        uint8_t numElements;",
+               $"        char str[{expectedLength+1}];",
+                "    } x2000_testRec;",
+                "} OD_Test_RAM_t;"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "OD_Test_ATTR_RAM OD_Test_RAM_t OD_Test_RAM = {",
+                "    .x2000_testRec = {",
+                "        .numElements = 0x00,",
+               $"        .str = {{{expectedInitialValues}}}",
+                "    }",
+                "};"}));
+            
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "typedef struct {",
+                "    OD_obj_record_t o_2000_testRec[2];",
+                "} OD_TestObjs_t;"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "static CO_PROGMEM OD_TestObjs_t OD_TestObjs = {",
+                "    .o_2000_testRec = {",
+                "        {",
+                "            .dataOrig = &OD_Test_RAM.x2000_testRec.numElements,",
+                "            .subIndex = 0,",
+                "            .attribute = ODA_SDO_RW | ODA_TRPDO,",
+                "            .dataLength = 1",
+                "        },",
+                "        {",
+                "            .dataOrig = &OD_Test_RAM.x2000_testRec.str[0],",
+                "            .subIndex = 1,",
+                "            .attribute = ODA_SDO_RW | ODA_TRPDO | ODA_STR,",
+               $"            .dataLength = {expectedLength}",
+                "        }",
+                "    }",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "static OD_Test_ATTR_OD OD_entry_t OD_TestList[] = {",
+                "    {0x2000, 0x02, ODT_REC, &OD_TestObjs.o_2000_testRec, NULL},",
+                "    {0x0000, 0x00, 0, NULL, NULL}",
+                "};"}));
+        }
+
+        [Fact]
+        public void TestRecordWithZeroLengthString()
+        {
+            ODentry od = new ODentry
+            {
+                objecttype = ObjectType.RECORD,
+                parameter_name = "test rec",
+                accesstype = EDSsharp.AccessType.ro,
+                Index = 0x2000
+            };
+
+            od.addsubobject(0, new ODentry("numElements", 0x2000, DataType.UNSIGNED8, "0", EDSsharp.AccessType.rw, PDOMappingType.optional));
+            od.addsubobject(1, new ODentry("str", 0x2000, DataType.VISIBLE_STRING, "", EDSsharp.AccessType.rw, PDOMappingType.optional));
+            _eds.ods.Add(0x2000, od);
+
+            GetExportResult(_eds, out var cfile, out var hfile);
+            Assert.True(FindExpectedLines(hfile, new List<string> {
+                "typedef struct {",
+                "    struct {",
+                "        uint8_t numElements;",
+                "    } x2000_testRec;",
+                "} OD_Test_RAM_t;"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "OD_Test_ATTR_RAM OD_Test_RAM_t OD_Test_RAM = {",
+                "    .x2000_testRec = {",
+                "        .numElements = 0x00",
+                "    }",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "typedef struct {",
+                "    OD_obj_record_t o_2000_testRec[2];",
+                "} OD_TestObjs_t;"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "static CO_PROGMEM OD_TestObjs_t OD_TestObjs = {",
+                "    .o_2000_testRec = {",
+                "        {",
+                "            .dataOrig = &OD_Test_RAM.x2000_testRec.numElements,",
+                "            .subIndex = 0,",
+                "            .attribute = ODA_SDO_RW | ODA_TRPDO,",
+                "            .dataLength = 1",
+                "        },",
+                "        {",
+                "            .dataOrig = NULL,",
+                "            .subIndex = 1,",
+                "            .attribute = ODA_SDO_RW | ODA_TRPDO | ODA_STR,",
+                "            .dataLength = 0",
+                "        }",
+                "    }",
+                "};"}));
+
+            Assert.True(FindExpectedLines(cfile, new List<string>
+            {
+                "static OD_Test_ATTR_OD OD_entry_t OD_TestList[] = {",
+                "    {0x2000, 0x02, ODT_REC, &OD_TestObjs.o_2000_testRec, NULL},",
+                "    {0x0000, 0x00, 0, NULL, NULL}",
+                "};"}));
         }
     }
 }


### PR DESCRIPTION
More unittests of the exporters, focusing on string in variable and record
The 4v code its little cumbersome, but i dont know any better way to it without exposing internal stuff.