### PR TITLE
Create release on tag action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: make release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: microsoft/setup-msbuild@v1.3
+    - name: Add Packages
+      run: |
+        dotnet restore
+    - name: Build
+      run: |
+        msbuild /property:Configuration=Release
+    - name: Check for release tag
+      run: |
+        $release = "${{ github.ref_name }}" -match "v[\d]*[.][\d]*[.][\d]*$"
+        $prerelease = If ($release) {"false"} else {"true"}
+        echo "prerelease=$prerelease" >> $env:GITHUB_ENV
+    - name: Make release package
+      run: |
+        Compress-Archive -CompressionLevel Optimal -Path "EDSEditorGUI\bin\Release\*" -DestinationPath ".\binary.zip"
+    - name: make release
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: ${{ env.prerelease }}
+        files: |
+          binary.zip


### PR DESCRIPTION
Think this is what you wanted @trojanobelix when you wanted binary to be available directly for testing
This will make releases when a tag starting with `v*.*.*` is pushed.
if it is v(number).(number).(number), like v.1.2.3 it is a release, but if it something like v1.2.3[not numbers] like v1.2.3-rc4 it is pre-release

When it makes (pre)release it attach the binary as a attachment

you can see the result on the last 2 releases on my test repo:
https://github.com/nimrof/CANopenEditor_gh_test

Not related to this, but you also have binary attached to all pr. under the checks tab (its a little hidden)

