### PR TITLE
created git-blame-ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# normalise line endings
+6336108d916fe2fe8167255257c71adf2cac062f


### PR DESCRIPTION
This file can be used by git to make it ignore some commits when using blame, that is very nice when i want to ignore formatting commits 

`git config blame.ignoreRevsFile .git-blame-ignore-revs`

more info here
[formatting changes ](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)

Github should do this automatically