### PR TITLE
Adding the contex menu on od column click back

### DIFF
--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -633,6 +633,11 @@ namespace ODEditor
         private void ListView_objects_ColumnClick(object sender, ColumnClickEventArgs e)
         {
             ((ListView)sender).SelectedItems.Clear();
+
+            contextMenu_object.Show(Cursor.Position);
+            PopulateObject();
+            PopulateSubList();
+
             ListView_objects_MouseClick(sender, new MouseEventArgs(MouseButtons.Right, 0, 0, 0, 0));
         }
 


### PR DESCRIPTION
Might be missing something here, but i cant find any other way to add entries than the old way, so putting it back.
Look at the issue for the bug/problem.

It was removed here https://github.com/CANopenNode/CANopenEditor/commit/ea3c0e5bd5522b8d90c8ee1b4d472ca70befb4a5

I might be very wrong here so please correct me

