### PR TITLE
110 canopeneditor exporting to xdd v10 format sets wrong type on highest sub index supported

### DIFF
--- a/Tests/XDDImportExportTest.cs
+++ b/Tests/XDDImportExportTest.cs
@@ -179,6 +179,7 @@ namespace Tests
             if (od.subobjects[1].PDOtype != PDOMappingType.optional)
                 throw new Exception("TPDOMappingType.optional not set in EDS for ARRAY");
 
+            Assert.True(od.subobjects[0].datatype == DataType.UNSIGNED8, "array subindex 0 datatype is changed");
 
 
         }

--- a/libEDSsharp/CanOpenXDD.cs
+++ b/libEDSsharp/CanOpenXDD.cs
@@ -496,7 +496,7 @@ namespace libEDSsharp
 
                         AppLayer.CANopenObjectList.CANopenObject[count].CANopenSubObject[subcount].edseditor_extension_notifyonchange = subod.prop.CO_flagsPDO;
 
-                        if (od.objecttype == ObjectType.ARRAY)
+                        if (od.objecttype == ObjectType.ARRAY && count != 0)
                             bytes = BitConverter.GetBytes((UInt16)od.datatype);
                         else
                             bytes = BitConverter.GetBytes((UInt16)subod.datatype);


### PR DESCRIPTION
Bugfix + test

information about the bug can be found in the issue #110 

Resolved #110 