### PR TITLE
Update colours to increase constrast.

### DIFF
--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -135,7 +135,7 @@ namespace ODEditor
         {
             var result = false;
 
-            if (button_saveChanges.BackColor == Color.Red)
+            if (button_saveChanges.BackColor == Color.Tomato)
             {
 
                 var answer = checkBox_autosave.Checked 
@@ -435,7 +435,7 @@ namespace ODEditor
         private void DataDirty(object sender, EventArgs e)
         {
             if (!justUpdating)
-                button_saveChanges.BackColor = Color.Red;
+                button_saveChanges.BackColor = Color.Tomato;
         }
 
         private void Button_saveChanges_Click(object sender, EventArgs e)

--- a/EDSEditorGUI/DevicePDOView2.cs
+++ b/EDSEditorGUI/DevicePDOView2.cs
@@ -62,7 +62,7 @@ namespace ODEditor
                 grid1[1, 3 + x * 8] = new MyHeader(string.Format("Byte {0}", x));
                 grid1[1, 3 + x * 8].ColumnSpan = 8;
 
-                grid1[1, 3 + x * 8].View.BackColor = Color.Red;
+                grid1[1, 3 + x * 8].View.BackColor = Color.Tomato;
 
             }
 
@@ -541,12 +541,12 @@ namespace ODEditor
                 view.Font = new Font(FontFamily.GenericSansSerif, 8, FontStyle.Bold);
                 view.WordWrap = true;
                 view.TextAlignment = DevAge.Drawing.ContentAlignment.MiddleCenter;
-                view.BackColor = Color.Red;
+                view.BackColor = Color.Tomato;
 
                 string text = value.ToString();
                 if (text == "0" || text == "8" || text == "16" || text == "24" || text == "32" || text == "40" || text == "48" || text == "56")
                 {
-                    view.ForeColor = Color.Red;
+                    view.ForeColor = Color.Tomato;
                 }
 
                 View = view;

--- a/EDSEditorGUI/DevicePDOView2.cs
+++ b/EDSEditorGUI/DevicePDOView2.cs
@@ -24,9 +24,9 @@ namespace ODEditor
 
         PDOSlot selectedslot = null;
 
-        CellBackColorAlternate viewNormal = new CellBackColorAlternate(Color.Khaki, Color.DarkKhaki);
-        CellBackColorAlternate viewEmpty = new CellBackColorAlternate(Color.Gray, Color.Gray);
-        CellBackColorAlternate viewCOB = new CellBackColorAlternate(Color.LightBlue, Color.Blue);
+        CellBackColorAlternate viewNormal = new CellBackColorAlternate(Color.Khaki, Color.LemonChiffon);
+        CellBackColorAlternate viewEmpty = new CellBackColorAlternate(Color.LightGray, Color.Gainsboro);
+        CellBackColorAlternate viewCOB = new CellBackColorAlternate(Color.LightBlue, Color.LightCyan);
 
         Point RightClickPoint = new Point(0, 0);
 

--- a/EDSEditorGUI/Form1.cs
+++ b/EDSEditorGUI/Form1.cs
@@ -452,7 +452,7 @@ namespace ODEditor
                         DeviceView d = (DeviceView)c;
                         if (d.eds.Dirty == true)
                         {
-                            page.BackColor = Color.Red;
+                            page.BackColor = Color.Tomato;
                         }
                         else
                         {

--- a/EDSEditorGUI/InsertObjects.cs
+++ b/EDSEditorGUI/InsertObjects.cs
@@ -150,7 +150,7 @@ namespace ODEditor
             DataGridViewCellStyle styleErr = new DataGridViewCellStyle
             {
                 Font = new Font(dataGridView.Font, FontStyle.Bold),
-                ForeColor = Color.Red
+                ForeColor = Color.Tomato
             };
 
             dataGridView.Rows.Clear();

--- a/EDSEditorGUI/ModuleInfo.cs
+++ b/EDSEditorGUI/ModuleInfo.cs
@@ -67,7 +67,7 @@ namespace ODEditor
                     }
                     else
                     {
-                        lvi2.BackColor = Color.Red;
+                        lvi2.BackColor = Color.Tomato;
                     }
                 }
 


### PR DESCRIPTION
Hi there! I've swapped some the red, blue and khaki colours used in the GUI to be lighter ones, so that the black text is readable. 
I did this because I was having a hard time viewing the COB/index value in the PDO mapping tab.

Before:
![before](https://github.com/user-attachments/assets/596cb68b-4981-4a84-bfdb-b2dca08afc6e)
After:
![after](https://github.com/user-attachments/assets/04266f6f-54db-4787-960f-82edf21e17cc)
![updated_saved](https://github.com/user-attachments/assets/14a48eaa-3306-4269-b25f-642de06e8333)

Screenshots at the base of the repo will need to be updated as I have not updated these.