### PR TITLE
Set default value to all subs without default value

### DIFF
--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -531,9 +531,13 @@ namespace ODEditor
                 {
                     od.prop.CO_accessSRDO = AccessSRDO.no;
                 }
+                for (ushort i = 1; i < od.parent.Nosubindexes; i++) {
+                    if (od.parent.subobjects[i].defaultvalue == "") {
+                        od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
+                    }
+                }
 
-                od.defaultvalue = textBox_defaultValue.Text;
-                od.actualvalue = textBox_actualValue.Text;
+               //  od.actualvalue = textBox_actualValue.Text;
                 od.HighLimit = textBox_highLimit.Text;
                 od.LowLimit = textBox_lowLimit.Text;
 

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -531,13 +531,16 @@ namespace ODEditor
                 {
                     od.prop.CO_accessSRDO = AccessSRDO.no;
                 }
-                for (ushort i = 1; i < od.parent.Nosubindexes; i++) {
-                    if (od.parent.subobjects[i].defaultvalue == "") {
+
+                for (ushort i = 1; i < od.parent.Nosubindexes; i++)
+                {
+                    if (od.parent.subobjects[i].defaultvalue == "")
+                    {
                         od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
                     }
                 }
 
-               //  od.actualvalue = textBox_actualValue.Text;
+                od.actualvalue = textBox_actualValue.Text;
                 od.HighLimit = textBox_highLimit.Text;
                 od.LowLimit = textBox_lowLimit.Text;
 


### PR DESCRIPTION
I find it annoying to set the default value individually for many subs. Often they should all be set to the same value.

The PR sets all empty values that are not set to the one just entered.
Can then be changed at any time. Better a wrong one than none. 

Not setting some leads to warnings when saving (I assume that DS301 does not allow this, but I am unsure). 

Comments wellcome.