### PR TITLE
Set defaut value to all subs with empty default values

### DIFF
--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -534,22 +534,29 @@ namespace ODEditor
 
                 // Default value
                 bool setDefaultValueToAll = false;
-                if (od.parent != null && od.Subindex > 0 && od.defaultvalue == "" && textBox_defaultValue.Text != "")
+                bool identicalDefaultValues = true;
+                string oldDefaultValue = "";
+                if (od.parent != null && od.Subindex > 1)
                 {
-                    DialogResult confirm = MessageBox.Show("Do you want to set the Default value to all unset default values in subobjects?", "Set to all?", MessageBoxButtons.YesNo);
-                    if (confirm == DialogResult.Yes)
+
+                    for (int i = 2; i < od.parent.Nosubindexes; i++)
                     {
-                        setDefaultValueToAll = true;
+                        identicalDefaultValues &= (od.parent.subobjects[(ushort)i].defaultvalue == od.parent.subobjects[(ushort)(i - 1)].defaultvalue);
+                    }
+
+                    if (identicalDefaultValues) {
+                        DialogResult confirm = MessageBox.Show("Do you want to set all identical default values in subobjects to this default value?", "Set to all?", MessageBoxButtons.YesNo);
+                        if (confirm == DialogResult.Yes)
+                        {
+                            setDefaultValueToAll = true;
+                        }
                     }
                 }
                 if (setDefaultValueToAll)
                 {
                     for (ushort i = 1; i < od.parent.Nosubindexes; i++)
                     {
-                        if (od.parent.subobjects[i].defaultvalue == "")
-                        {
                             od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
-                        }
                     }
                 }
                 else

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -536,7 +536,7 @@ namespace ODEditor
                 bool setDefaultValueToAll = false;
                 if (od.parent != null && od.Subindex > 0 && od.defaultvalue == "" && textBox_defaultValue.Text != "")
                 {
-                    DialogResult confirm = MessageBox.Show("Do you want to apply Default value to all unset subobjects?", MessageBoxButtons.YesNo);
+                    DialogResult confirm = MessageBox.Show("Do you want to set the Default value to all unset default values in subobjects?", "Set to all?", MessageBoxButtons.YesNo);
                     if (confirm == DialogResult.Yes)
                     {
                         setDefaultValueToAll = true;

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -532,12 +532,29 @@ namespace ODEditor
                     od.prop.CO_accessSRDO = AccessSRDO.no;
                 }
 
-                for (ushort i = 1; i < od.parent.Nosubindexes; i++)
+                // Default value
+                bool setDefaultValueToAll = false;
+                if (od.parent != null && od.Subindex > 0 && od.defaultvalue == "" && textBox_defaultValue.Text != "")
                 {
-                    if (od.parent.subobjects[i].defaultvalue == "")
+                    DialogResult confirm = MessageBox.Show("Do you want to apply Default value to all unset subobjects?", MessageBoxButtons.YesNo);
+                    if (confirm == DialogResult.Yes)
                     {
-                        od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
+                        setDefaultValueToAll = true;
                     }
+                }
+                if (setDefaultValueToAll)
+                {
+                    for (ushort i = 1; i < od.parent.Nosubindexes; i++)
+                    {
+                        if (od.parent.subobjects[i].defaultvalue == "")
+                        {
+                            od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
+                        }
+                    }
+                }
+                else
+                {
+                    od.defaultvalue = textBox_defaultValue.Text;
                 }
 
                 od.actualvalue = textBox_actualValue.Text;

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -543,13 +543,17 @@ namespace ODEditor
 
                 bool setDefaultValueToAll = false;
                 bool identicalDefaultValues = true;
-
+                string lastdefaultvalue;
                 if (od.parent != null && od.parent.Nosubindexes > 2)
                 {
-
-                    for (int i = 2; i < od.parent.Nosubindexes; i++)
+                    lastdefaultvalue = od.parent.subobjects[1].defaultvalue;
+                    foreach (ODentry subod in od.parent.subobjects.Values)
                     {
-                        identicalDefaultValues &= ((od.parent.subobjects[(ushort)i].defaultvalue == od.parent.subobjects[(ushort)(i - 1)].defaultvalue) && (od.parent.subobjects[(ushort)i].defaultvalue != textBox_defaultValue.Text));
+                        if (subod.Subindex > 0)
+                        {
+                           identicalDefaultValues &= (subod.defaultvalue ==  lastdefaultvalue)&& (subod.defaultvalue != textBox_defaultValue.Text);
+                           lastdefaultvalue = subod.defaultvalue;
+                        }
                     }
                         
                     if (identicalDefaultValues) {

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -533,26 +533,34 @@ namespace ODEditor
                 }
 
                 // Default value
+                if (listView_subObjects.SelectedItems.Count > 1) {
+                    for (ushort i = 0; i < listView_subObjects.SelectedItems.Count; i++)
+                    {
+                        od.parent.subobjects[(ushort) Convert.ToInt32(listView_subObjects.SelectedItems[i].Text,16)].defaultvalue = textBox_defaultValue.Text;
+                    }
+                }
+
+
                 bool setDefaultValueToAll = false;
                 bool identicalDefaultValues = true;
-                string oldDefaultValue = "";
-                if (od.parent != null && od.Subindex > 1)
+
+                if (od.parent != null && od.parent.Nosubindexes > 2)
                 {
 
                     for (int i = 2; i < od.parent.Nosubindexes; i++)
                     {
                         identicalDefaultValues &= (od.parent.subobjects[(ushort)i].defaultvalue == od.parent.subobjects[(ushort)(i - 1)].defaultvalue);
                     }
-
+                        
                     if (identicalDefaultValues) {
-                        DialogResult confirm = MessageBox.Show("Do you want to set all identical default values in subobjects to this default value?", "Set to all?", MessageBoxButtons.YesNo);
+                            DialogResult confirm = MessageBox.Show("Do you want to set all identical default values in subobjects to this default value?", "Set to all?", MessageBoxButtons.YesNo);
                         if (confirm == DialogResult.Yes)
                         {
                             setDefaultValueToAll = true;
                         }
                     }
                 }
-                if (setDefaultValueToAll)
+                        if (setDefaultValueToAll)
                 {
                     for (ushort i = 1; i < od.parent.Nosubindexes; i++)
                     {

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -531,9 +531,13 @@ namespace ODEditor
                 {
                     od.prop.CO_accessSRDO = AccessSRDO.no;
                 }
+                for (ushort i = 1; i < od.parent.Nosubindexes; i++) {
+                    if (od.parent.subobjects[i].defaultvalue == "") {
+                        od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
+                    }
+                }
 
-                od.defaultvalue = textBox_defaultValue.Text;
-                od.actualvalue = textBox_actualValue.Text;
+               //  od.actualvalue = textBox_actualValue.Text;
                 od.HighLimit = textBox_highLimit.Text;
                 od.LowLimit = textBox_lowLimit.Text;
 

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -549,7 +549,7 @@ namespace ODEditor
 
                     for (int i = 2; i < od.parent.Nosubindexes; i++)
                     {
-                        identicalDefaultValues &= (od.parent.subobjects[(ushort)i].defaultvalue == od.parent.subobjects[(ushort)(i - 1)].defaultvalue);
+                        identicalDefaultValues &= ((od.parent.subobjects[(ushort)i].defaultvalue == od.parent.subobjects[(ushort)(i - 1)].defaultvalue) && (od.parent.subobjects[(ushort)i].defaultvalue != textBox_defaultValue.Text));
                     }
                         
                     if (identicalDefaultValues) {

--- a/EDSEditorGUI/DeviceODView.cs
+++ b/EDSEditorGUI/DeviceODView.cs
@@ -531,13 +531,16 @@ namespace ODEditor
                 {
                     od.prop.CO_accessSRDO = AccessSRDO.no;
                 }
-                for (ushort i = 1; i < od.parent.Nosubindexes; i++) {
-                    if (od.parent.subobjects[i].defaultvalue == "") {
+
+                for (ushort i = 1; i < od.parent.Nosubindexes; i++)
+                {
+                    if (od.parent.subobjects[i].defaultvalue == "")
+                    {
                         od.parent.subobjects[i].defaultvalue = textBox_defaultValue.Text;
                     }
                 }
 
-               //  od.actualvalue = textBox_actualValue.Text;
+                od.actualvalue = textBox_actualValue.Text;
                 od.HighLimit = textBox_highLimit.Text;
                 od.LowLimit = textBox_lowLimit.Text;
 

--- a/EDSEditorGUI/DevicePDOView2.cs
+++ b/EDSEditorGUI/DevicePDOView2.cs
@@ -460,7 +460,12 @@ namespace ODEditor
                 int ordinal = 0;
                 foreach (ODentry entry in slot.Mapping)
                 {
+                    if ((bitoff + entry.Sizeofdatatype()) > 64)
                     {
+                       string toDisplay = string.Join(Environment.NewLine, slot.Mapping);
+                       MessageBox.Show(string.Format("Invalid TXPDO mapping parameters in 0x{0:X}!\r\nTrying to map more than the maximum lenght of a CAN message (8 bytes).\r\n\r\nMembers are:\r\n{1}", slot.ConfigurationIndex,toDisplay));
+                        break;
+                    }
                         string target = slot.getTargetName(entry);
                         grid1[row + 2, bitoff + 3] = new SourceGrid.Cells.Cell(target, comboStandard);
                         grid1[row + 2, bitoff + 3].ColumnSpan = entry.Sizeofdatatype();
@@ -480,14 +485,9 @@ namespace ODEditor
 
                         grid1[row + 2, bitoff + 3].AddController(vcc);
                         bitoff += entry.Sizeofdatatype();
-                    }
+
 
                     ordinal++;
-
-                    if (bitoff > 64) {
-                        MessageBox.Show(string.Format("Invalid TXPDO mapping parameters in 0x{0:X}. Trying to map more than 64 bit (8 Bytes). CAN message maximum lenght is 8 Byte", slot.ConfigurationIndex));
-                        break;
-                    }
 
                 }
 


### PR DESCRIPTION
I find it annoying to set the default value individually for many subs. Often they should all be set to the same value.

The PR sets all empty subs that have no default value to the one just entered.
Can then be changed at any time. Better a wrong one than none.

Not setting a value to all subs leads to warnings when saving (I assume that DS301 does not allow this, but I am unsure).

Comments wellcome.