### PR TITLE
Use single automapper version

### DIFF
--- a/libEDSsharp/CanOpenEDSMapping.cs
+++ b/libEDSsharp/CanOpenEDSMapping.cs
@@ -90,6 +90,15 @@ namespace libEDSsharp
                 .ForMember(dest => dest.ModificationDate, opt => opt.MapFrom(src => src.ModificationTime.ToDateTime().ToString("MM-dd-yyyy")))
                 .ForMember(dest => dest.ModificationTime, opt => opt.MapFrom(src => src.ModificationTime.ToDateTime().ToString("h:mmtt")));
                 cfg.CreateMap<CanOpen_DeviceInfo, DeviceInfo>()
+                .ForMember(dest => dest.BaudRate_10, opt => opt.MapFrom(src => src.BaudRate10))
+                .ForMember(dest => dest.BaudRate_20, opt => opt.MapFrom(src => src.BaudRate20))
+                .ForMember(dest => dest.BaudRate_50, opt => opt.MapFrom(src => src.BaudRate50))
+                .ForMember(dest => dest.BaudRate_125, opt => opt.MapFrom(src => src.BaudRate125))
+                .ForMember(dest => dest.BaudRate_250, opt => opt.MapFrom(src => src.BaudRate250))
+                .ForMember(dest => dest.BaudRate_500, opt => opt.MapFrom(src => src.BaudRate500))
+                .ForMember(dest => dest.BaudRate_800, opt => opt.MapFrom(src => src.BaudRate800))
+                .ForMember(dest => dest.BaudRate_1000, opt => opt.MapFrom(src => src.BaudRate1000))
+                .ForMember(dest => dest.BaudRate_auto, opt => opt.MapFrom(src => src.BaudRateAuto))
                 .ForMember(dest => dest.VendorNumber, opt => opt.Ignore())
                 .ForMember(dest => dest.ProductNumber, opt => opt.Ignore())
                 .ForMember(dest => dest.RevisionNumber, opt => opt.Ignore())
@@ -113,7 +122,11 @@ namespace libEDSsharp
                 .ForMember(dest => dest.LSS_SerialNumber, opt => opt.Ignore());
                 cfg.CreateMap<OdObject, CustomProperties>()
                 .ForMember(dest => dest.CO_accessSRDO, opt => opt.Ignore())
-                .ForMember(dest => dest.CO_stringLengthMin, opt => opt.Ignore());
+                .ForMember(dest => dest.CO_stringLengthMin, opt => opt.Ignore())
+                .ForMember(dest => dest.CO_disabled, opt => opt.MapFrom(src => src.Disabled))
+                .ForMember(dest => dest.CO_countLabel, opt => opt.MapFrom(src => src.CountLabel))
+                .ForMember(dest => dest.CO_storageGroup, opt => opt.MapFrom(src => src.StorageGroup))
+                .ForMember(dest => dest.CO_flagsPDO, opt => opt.MapFrom(src => src.FlagsPDO));
                 cfg.CreateMap<OdObject.Types.ObjectType, ObjectType>().ConvertUsing<ODTypeResolver>();
                 cfg.CreateMap<OdObject, ODentry>()
                 .ForMember(dest => dest.Index, opt => opt.Ignore())

--- a/libEDSsharp/libEDSsharp.csproj
+++ b/libEDSsharp/libEDSsharp.csproj
@@ -47,7 +47,8 @@
     <PackageReference Include="System.CodeDom" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Google.Protobuf" Version="3.27.2" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.27.2" />
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Got sort of [this error](https://stackoverflow.com/a/69404546) when i needed to use the eds->protobuffer converter i gui2.

Its caused by using different version of automapper in the solution.
So upgrade it for .net8 that is used in gui2, but the new version needed more to be explicitly mapped so i fixed that too.