### PR TITLE
msbuild: allow the dotnet for macosx installs to target windows

### DIFF
--- a/EDSEditorGUI/EDSEditorGUI.csproj
+++ b/EDSEditorGUI/EDSEditorGUI.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks Condition="'$(BuildNet481)' == 'true'">net481</TargetFrameworks>
     <TargetFrameworks Condition="'$(BuildNet8)' == 'true'">net8.0-windows</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net481;net8.0-windows</TargetFrameworks>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ODEditor</RootNamespace>
     <AssemblyName>EDSEditor</AssemblyName>
@@ -104,6 +105,6 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <PropertyGroup>
-    <PreBuildEvent>git describe --tags --long --dirty &gt; "$(MSBuildProjectDirectory)\version.txt" || exit 0</PreBuildEvent>
+    <PreBuildEvent>git describe --tags --long --dirty &gt; "$(MSBuildProjectDirectory)$([System.IO.Path]::DirectorySeparatorChar)version.txt" || exit 0</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This makes the build complete on a dotnet install for a mac so that it is easier to verify the build and setup.