### PR TITLE
edssharp: add another extension for the EDS file for CountLabel

### DIFF
--- a/libEDSsharp/CanOpenEDS.cs
+++ b/libEDSsharp/CanOpenEDS.cs
@@ -387,7 +387,14 @@ namespace libEDSsharp
             }
 
             writer.WriteLine(string.Format("ObjectType=0x{0:X}", (int)objecttype));
-            writer.WriteLine(string.Format(";StorageLocation={0}", prop.CO_storageGroup));
+            if (prop.CO_countLabel != "")
+            {
+                writer.WriteLine(string.Format(";CountLabel={0}", prop.CO_countLabel));
+            }
+            if (prop.CO_storageGroup != "")
+            {
+                writer.WriteLine(string.Format(";StorageLocation={0}", prop.CO_storageGroup));
+            }
 
             if (objecttype == ObjectType.ARRAY)
             {
@@ -521,9 +528,9 @@ namespace libEDSsharp
                         }
                     }
                     else
-                    //Only allow our own extensions to populate the key/value pair
                     {
-                        if (key == "StorageLocation" || key == "TPDODetectCos")
+                        //Only allow our own extensions to populate the key/value pair
+                        if (key == "CountLabel" || key == "StorageLocation" || key == "TPDODetectCos")
                         {
                             try
                             {
@@ -618,6 +625,11 @@ namespace libEDSsharp
                 }
 
                 //Access Type
+                if (kvp.Value.ContainsKey("CountLabel"))
+                {
+                    od.prop.CO_countLabel = kvp.Value["CountLabel"];
+                }
+
                 if (kvp.Value.ContainsKey("StorageLocation"))
                 {
                     od.prop.CO_storageGroup = kvp.Value["StorageLocation"];


### PR DESCRIPTION
The count label is required to compile against the CANopenNode v4 library since the definitions are checked by code like the following in CANopen.c
```
    #if OD_CNT_NMT != 1
     #error OD_CNT_NMT from OD.h not correct!
    #endif
```

This problem is exhibited when there is no xpd file that has the custom properties and there is only an EDS file available. The StorageLocation is an example of setting the custom property for the CO_storageGroup and this is adding a similar extension for the CO_countLabel.

An example eds for NMT 0x1000 is shown below
```
    [1000]
    ParameterName=Device type
    ObjectType=0x7
    ;CountLabel=NMT
    ;StorageLocation=ROM
    DataType=0x0007
    AccessType=ro
    DefaultValue=0x00000000
    PDOMapping=0
```