### PR TITLE
[CLI][FIX] Fixed a bug where parity of arguments mattered too much

### DIFF
--- a/EDSSharp/Program.cs
+++ b/EDSSharp/Program.cs
@@ -26,13 +26,11 @@ namespace EDSSharp
                     {
                         argskvp.Add("--infile", args[++argv]);
                     }
-
-                    if (args[argv] == "--outfile")
+                    else if (args[argv] == "--outfile")
                     {
                         argskvp.Add("--outfile", args[++argv]);
                     }
-
-                    if (args[argv] == "--type")
+                    else if (args[argv] == "--type")
                     {
                         argskvp.Add("--type", args[++argv]);
                     }
@@ -84,7 +82,6 @@ namespace EDSSharp
 
         private static void openEDSfile(string infile)
         {
-          
             eds.Loadfile(infile);
         }
 


### PR DESCRIPTION
EDSSHARP was meant to be executed with a compiled version but I found it easier, on Linux, to use dotnet and not compile. As such, the command I used to execute the program (so without any argument) had an even number of arguments which didn't work because this program is meant to be used with an odd number. This behaviour being quite arbitrary, I decided to make it more flexible by enabling the program to search arguments wherever they might be.
For the tests, I tried executing the program with arguments in multiple places and it worked (that's not a lot I know XD).

I have read and agree to the Developer's Certificate of Origin 1.1