### PR TITLE
Update sourcegrid for .net 8/9

### DIFF
--- a/EDSEditorGUI/EDSEditorGUI.csproj
+++ b/EDSEditorGUI/EDSEditorGUI.csproj
@@ -99,9 +99,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="SourceGrid" Version="4.4.0" Condition="'$(TargetFramework)' == 'net481'"/>
-    <PackageReference Include="SourceGrid-huanlin" Version="6.0.10" Condition="'$(TargetFramework)' == 'net8.0-windows'"/>
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0-windows'"/>
+    <PackageReference Include="SourceGrid" Version="4.4.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="SourceGrid-huanlin" Version="6.1.1" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.0" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
Update sourcegrid for .net 8/9 to version v6.1.1. 
Fixes #199 