### PR TITLE
Check if the sub index for PDO mapping is still valid (might be deleted)

### DIFF
--- a/libEDSsharp/PDOHelper.cs
+++ b/libEDSsharp/PDOHelper.cs
@@ -366,8 +366,13 @@ namespace libEDSsharp
                             }
                             else
                                 maptarget.entry = eds.ods[pdoindex].Getsubobject(pdosub);
-
-                            if ((maptarget.entry.prop.CO_disabled == false) &&
+                            // Check if mapped sub index was found in OD 
+                            if (maptarget.entry == null)         
+                            {
+                                Console.WriteLine("MAPPING FAILED, OBJEKT NOT FOUND");
+                                continue;
+                            }
+                            else if ((maptarget.entry.prop.CO_disabled == false) &&
                                 (datasize <= maptarget.entry.Sizeofdatatype()) && 
                                 (datasize > 0))
                             {


### PR DESCRIPTION
Prevent crash if a mapped sub was deleted from OD.

**To reproduce:**

Create object with multiple subs.
Map subs.
Delete mapped subs in OD.
Save.

**Old:**
Crash dereferencing null pointer while creating mapping table.

**New:** 
Mapping of the deleted sub is removed when creating the mapping table.