### PR TITLE
Repair issues in 'Reports' generation.

### DIFF
--- a/EDSEditorGUI/Form1.cs
+++ b/EDSEditorGUI/Form1.cs
@@ -27,6 +27,7 @@ using System.Windows.Forms;
 using System.IO;
 using libEDSsharp;
 using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using System.Diagnostics;
 
 namespace ODEditor
 {
@@ -1038,7 +1039,14 @@ namespace ODEditor
                     docgenMarkup.genmddoc(temp2, dv.eds);
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
-                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", $"/c start {temp2}"));
+                        // By using "cmd /c start" you avoid the child process to be attached to the current
+                        // process so the report viewer does not close when leaving the EDS editor.
+                        // {temp2} is quoted too, so spaces in the path do not cause problems.
+                        Process.Start(new ProcessStartInfo {
+                            FileName = "cmd",
+                            Arguments = $"/c start \"\" \"{temp2}\"",
+                            WindowStyle= ProcessWindowStyle.Hidden
+                        });
                     }
                     if (IsRunningOnMono())
                     {

--- a/EDSEditorGUI/style.css
+++ b/EDSEditorGUI/style.css
@@ -112,3 +112,8 @@ table tr:hover td {
 {
 width: 90%;
 }
+
+.error
+{
+	color: red;
+}

--- a/libEDSsharp/NetworkPDOreport.cs
+++ b/libEDSsharp/NetworkPDOreport.cs
@@ -179,7 +179,15 @@ namespace libEDSsharp
                                 }
                                 else
                                 {
-                                    name = eds.ods[index].Getsubobject(subindex).parameter_name;
+                                    ODentry current_sdo = eds.ods[index].Getsubobject(subindex);
+                                    if (current_sdo != null)
+                                    {
+                                        name = current_sdo.parameter_name;
+                                    }
+                                    else
+                                    {
+                                        name = string.Format("<p class=\"error\">Error: subindex is missing in SDO!</p>");
+                                    }
                                 }
 
 


### PR DESCRIPTION
Fixes:
1) Fix an exception in the code when an non-existing subindex is referenced in a TPDO.  See #222 for details and reproduction.
2) Fix an error when Reports->Documentation is called and you have spaces in your windows profile.

1) Tested with a file that has a mapping to a non-existing sub-index, it now reports this error in the generated report with a RED colored message (via a style sheet ref) that the subindex is missing. To my opinion no error pop-up or something is needed because the goal is to make a report, so it suits the purpose.

2) When you have a userprofile that contains spaces the generated temp file path for the *.md file also contains spaces and the viewer pop-up did not show up but gave an error of a missing file. The file is now quoted and the call is "modernized".

I have read the contributing guidelines, I agree to following them and I agree to the Developer's Certificate of Origin 1.1