### PR TITLE
Automapper upgrade v10 and v13 to v16

### DIFF
--- a/EDSEditorGUI2/EDSEditorGUI2.csproj
+++ b/EDSEditorGUI2/EDSEditorGUI2.csproj
@@ -36,6 +36,6 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
   </ItemGroup>
 </Project>

--- a/EDSEditorGUI2/Mapper/ProtobufferViewModelMapper.cs
+++ b/EDSEditorGUI2/Mapper/ProtobufferViewModelMapper.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Google.Protobuf.WellKnownTypes;
 using LibCanOpen;
+using Microsoft.Extensions.Logging;
 using System;
 
 namespace EDSEditorGUI2.Mapper
@@ -27,7 +28,7 @@ namespace EDSEditorGUI2.Mapper
                 .ForMember(dest => dest.Objects, opt => opt.MapFrom(src => src.Objects));
                 cfg.CreateMap<CanOpen_DeviceInfo, ViewModels.DeviceInfo>();
                 cfg.CreateMap<CanOpen_DeviceCommissioning, ViewModels.DeviceCommissioning>();
-            });
+            }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
             config.AssertConfigurationIsValid();
             var mapper = config.CreateMapper();
             var result = mapper.Map<ViewModels.Device>(source);
@@ -42,7 +43,7 @@ namespace EDSEditorGUI2.Mapper
                 {
                     cfg.CreateMap<OdObject, ViewModels.OdObject>();
                     cfg.CreateMap<OdSubObject, ViewModels.OdSubObject>();
-                });
+                }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
                 config.AssertConfigurationIsValid();
                 var mapper = config.CreateMapper();
 
@@ -59,7 +60,7 @@ namespace EDSEditorGUI2.Mapper
                 {
                     cfg.CreateMap<ViewModels.OdObject, OdObject>();
                     cfg.CreateMap<ViewModels.OdSubObject, OdSubObject>();
-                });
+                }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
                 config.AssertConfigurationIsValid();
                 var mapper = config.CreateMapper();
 
@@ -77,7 +78,7 @@ namespace EDSEditorGUI2.Mapper
             var config = new MapperConfiguration(cfg =>
             {
                 //TODO
-            });
+            }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
             config.AssertConfigurationIsValid();
             var mapper = config.CreateMapper();
             var result = mapper.Map<CanOpenDevice>(source);

--- a/README.md
+++ b/README.md
@@ -250,14 +250,21 @@ Contributors
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/Sl-Alex">
+                    <img src="https://avatars.githubusercontent.com/u/7002691?v=4" width="100;" alt="Sl-Alex"/>
+                    <br />
+                    <sub><b>Sl-Alex</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
                 <a href="https://github.com/rgruening">
                     <img src="https://avatars.githubusercontent.com/u/72022918?v=4" width="100;" alt="rgruening"/>
                     <br />
                     <sub><b>rgruening</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/Barzello">
                     <img src="https://avatars.githubusercontent.com/u/52344726?v=4" width="100;" alt="Barzello"/>
@@ -293,6 +300,8 @@ Contributors
                     <sub><b>DaMutz</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/StormOli">
                     <img src="https://avatars.githubusercontent.com/u/4819887?v=4" width="100;" alt="StormOli"/>
@@ -300,8 +309,6 @@ Contributors
                     <sub><b>StormOli</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/possibly-not">
                     <img src="https://avatars.githubusercontent.com/u/12588174?v=4" width="100;" alt="possibly-not"/>

--- a/libEDSsharp/CanOpenEDSMapping.cs
+++ b/libEDSsharp/CanOpenEDSMapping.cs
@@ -20,6 +20,7 @@
 using AutoMapper;
 using Google.Protobuf.WellKnownTypes;
 using LibCanOpen;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -167,7 +168,7 @@ namespace libEDSsharp
                 .ForMember(dest => dest.objecttype, opt => opt.Ignore())
                 .ForMember(dest => dest.Description, opt => opt.Ignore())
                 .ForMember(dest => dest.subobjects, opt => opt.Ignore());
-            });
+            }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
             config.AssertConfigurationIsValid();
             var mapper = config.CreateMapper();
 
@@ -236,7 +237,7 @@ namespace libEDSsharp
                 .ForMember(dest => dest.Pdo, opt => opt.MapFrom(src => src.accesstype))
                 .ForMember(dest => dest.Srdo, opt => opt.MapFrom(src => src.prop.CO_accessSRDO))
                 .ForMember(dest => dest.StringLengthMin, opt => opt.MapFrom(src => src.prop.CO_stringLengthMin));
-            });
+            }, LoggerFactory.Create(builder => { builder.AddDebug(); }));
 
             config.AssertConfigurationIsValid();
             var mapper = config.CreateMapper();

--- a/libEDSsharp/libEDSsharp.csproj
+++ b/libEDSsharp/libEDSsharp.csproj
@@ -47,8 +47,8 @@
     <PackageReference Include="System.CodeDom" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Google.Protobuf" Version="3.27.2" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.27.2" />
-    <PackageReference Include="AutoMapper" Version="10.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="AutoMapper" Version="13.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded automapper for a few reasons:
* Fix the runtime problem with tester https://github.com/CANopenNode/CANopenEditor/actions/runs/27990391290/job/82841311369
* Upgrade automapper from versions that has high priority vulnerability https://github.com/advisories/GHSA-rvv3-g6hj-g44x

A nice effect is that the never version supports .net framwork and .net so we can use the same version for all builds