### PR TITLE
228 cloning an object ending with a number create an exception

### DIFF
--- a/EDSEditorGUI/InsertObjects.cs
+++ b/EDSEditorGUI/InsertObjects.cs
@@ -159,7 +159,7 @@ namespace ODEditor
             int j = 1;
             foreach (ODentry od in srcObjects.Values)
             {
-                String numpattern = @"(\w*\d+\Z)";
+                String numpattern = @"(\d+\Z)";
                 string newname;
 
                 string[] words = Regex.Split(od.parameter_name, numpattern);
@@ -235,7 +235,7 @@ namespace ODEditor
                             UInt16 newIndex = (UInt16)(od.Index + o);
                             ODentry newObject = od.Clone();
 
-                            String pattern = @"(\w*\d+\Z)";
+                            String pattern = @"(\d+\Z)";
 
                             string[] words = Regex.Split(od.parameter_name, pattern);
                             // MatchCollection nummatches = System.Text.RegularExpressions.Regex.Matches(od.parameter_name, numpattern);

--- a/README.md
+++ b/README.md
@@ -250,14 +250,21 @@ Contributors
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/Sl-Alex">
+                    <img src="https://avatars.githubusercontent.com/u/7002691?v=4" width="100;" alt="Sl-Alex"/>
+                    <br />
+                    <sub><b>Sl-Alex</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
                 <a href="https://github.com/rgruening">
                     <img src="https://avatars.githubusercontent.com/u/72022918?v=4" width="100;" alt="rgruening"/>
                     <br />
                     <sub><b>rgruening</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/Barzello">
                     <img src="https://avatars.githubusercontent.com/u/52344726?v=4" width="100;" alt="Barzello"/>
@@ -293,6 +300,8 @@ Contributors
                     <sub><b>DaMutz</b></sub>
                 </a>
             </td>
+		</tr>
+		<tr>
             <td align="center">
                 <a href="https://github.com/StormOli">
                     <img src="https://avatars.githubusercontent.com/u/4819887?v=4" width="100;" alt="StormOli"/>
@@ -300,8 +309,6 @@ Contributors
                     <sub><b>StormOli</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
             <td align="center">
                 <a href="https://github.com/possibly-not">
                     <img src="https://avatars.githubusercontent.com/u/12588174?v=4" width="100;" alt="possibly-not"/>


### PR DESCRIPTION
Minor changes to the regex so it works with names like this:
text1

Tested with this:
New Object 0
New Object 22
New24
123
asd

closes #228

Test fails of the same reasons that this pr. fixes: https://github.com/CANopenNode/CANopenEditor/pull/230